### PR TITLE
Implement similarity score thresholding, removing top k

### DIFF
--- a/.config/config.json
+++ b/.config/config.json
@@ -1,0 +1,6 @@
+{
+    "dot_product_threshold_1" : 0.2,
+    "dot_product_threshold_2" : 0.5,
+    "max_context_records" : 30,
+    "min_records_for_summarisation" : 5
+}

--- a/app/main.py
+++ b/app/main.py
@@ -67,9 +67,9 @@ model = load_model(HF_MODEL_NAME)
 filter_options = load_filter_dropdown_values(FILTER_OPTIONS_PATH)
 
 config = load_config(".config/config.json")
-similarity_threshold = config.get("dot_product_threshold_1")
-max_context_records = config.get("dot_product_threshold_1")
-min_records_for_summarisation = config.get("min_records_for_summarisation")
+similarity_threshold = float(config.get("dot_product_threshold_1"))
+max_context_records = int(config.get("dot_product_threshold_1"))
+min_records_for_summarisation = int(config.get("min_records_for_summarisation"))
 
 
 def main():

--- a/evaluation/run_evaluation.py
+++ b/evaluation/run_evaluation.py
@@ -6,7 +6,7 @@ from src.collection.evaluate_collection import (
     get_all_regex_ids,
     assess_scroll_retrieval,
 )
-from src.utils.utils import load_qdrant_client
+from src.utils.utils import load_qdrant_client, load_config
 
 # Get env vars
 PUBLISHING_PROJECT_ID = os.getenv("PUBLISHING_PROJECT_ID")
@@ -14,6 +14,11 @@ EVALUATION_TABLE = os.getenv("EVALUATION_TABLE")
 QDRANT_HOST = os.getenv("QDRANT_HOST")
 QDRANT_PORT = os.getenv("QDRANT_PORT")
 COLLECTION_NAME = os.getenv("COLLECTION_NAME")
+HF_MODEL_NAME = os.getenv("HF_MODEL_NAME")
+
+config = load_config(".config/config.json")
+similarity_threshold = float(config.get("dot_product_threshold_1"))
+print(f"Similarity threshold: {similarity_threshold}")
 
 
 def main():
@@ -32,9 +37,10 @@ def main():
     ss_results = assess_retrieval_accuracy(
         client=client,
         collection_name=COLLECTION_NAME,
+        model_name=HF_MODEL_NAME,
         data=data,
         regex_ids=regex_ids,
-        k_threshold=100,
+        score_threshold=similarity_threshold,
     )
     print(f"Dot product search n results: {len(ss_results)}")
 

--- a/src/collection/query_collection.py
+++ b/src/collection/query_collection.py
@@ -2,8 +2,12 @@ from qdrant_client import QdrantClient
 from qdrant_client.http.models import FieldCondition, Filter, MatchAny
 
 
-def get_top_k_results(
-    client: QdrantClient, collection_name: str, query_embedding, k: int, filter_dict={}
+def get_semantically_similar_results(
+    client: QdrantClient,
+    collection_name: str,
+    query_embedding,
+    score_threshold: float,
+    filter_dict={},
 ):
     """Retrieve top k results from collection
 
@@ -11,6 +15,7 @@ def get_top_k_results(
         client (QdrantClient): The  Qdrant client.
         collection_name (str): The name of the collection.
         query_embedding (list): The query vector.
+        score_threshold (float): The minimum score to return.
         filter_dict (dict, optional): The keys and values to filter on. Defaults to {}.
 
     Returns:
@@ -31,11 +36,13 @@ def get_top_k_results(
             collection_name=collection_name,
             query_vector=query_embedding,
             query_filter=filter,
-            limit=k,
+            score_threshold=score_threshold,
         )
     else:
         search_result = client.search(
-            collection_name=collection_name, query_vector=query_embedding, limit=k
+            collection_name=collection_name,
+            query_vector=query_embedding,
+            score_threshold=score_threshold,
         )
 
     return search_result

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -5,6 +5,25 @@ from qdrant_client import QdrantClient
 from sentence_transformers import SentenceTransformer
 
 
+def load_config(config_file_path):
+    """
+    Load configuration variables from a JSON file.
+
+    Args:
+        config_file_path (str): The file path to the configuration file.
+
+    Returns:
+        dict: A dictionary containing the configuration variables.
+
+    Raises:
+        FileNotFoundError: If the specified file does not exist.
+        json.JSONDecodeError: If the file is not a valid JSON.
+    """
+    with open(config_file_path, "r") as file:
+        config = json.load(file)
+    return config
+
+
 def load_qdrant_client(qdrant_host: str, port: int) -> QdrantClient:
     client = QdrantClient(qdrant_host, port=port)
     return client


### PR DESCRIPTION
- removes parameter k from the repo - replaces it with a simple similarity score threshold.
- adds a config file to store this threshold and other params
- N.B. threshold will of course depend on the metric we are using. This is set at a collection level when creating the collection. In the interests of simplicity, I have not put this in config in this PR, but it would be advisable to store thresholds and distance metrics together in config, to avoid issues.